### PR TITLE
Fix Delta merge error by overwriting schema

### DIFF
--- a/events.py
+++ b/events.py
@@ -385,6 +385,7 @@ class DataIntegrator:
             df.write.mode("overwrite")
             .format("delta")
             .option("mergeSchema", "true")
+            .option("overwriteSchema", "true")
             .save(adls_path)
         )
 


### PR DESCRIPTION
## Summary
- add `overwriteSchema` option when writing Delta files to ADLS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a49360f58832588ac9c0c32256d7b